### PR TITLE
Changes to Linux routing setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tproxy-config"
-version = "3.0.2"
+version = "4.0.0"
 edition = "2021"
 description = "Transparent proxy configuration"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ pub struct TproxyState {
     pub(crate) umount_resolvconf: bool,
     pub(crate) restore_resolvconf_content: Option<Vec<u8>>,
     pub(crate) tproxy_removed_done: bool,
+    #[cfg(target_os = "linux")]
+    pub(crate) restore_ipv4_route: Option<Vec<String>>,
+    #[cfg(target_os = "linux")]
+    pub(crate) restore_ipv6_route: Option<Vec<String>>,
 }
 
 #[allow(dead_code)]

--- a/src/tproxy_args.rs
+++ b/src/tproxy_args.rs
@@ -12,6 +12,8 @@ pub struct TproxyArgs {
     pub tun_name: String,
     pub proxy_addr: SocketAddr,
     pub bypass_ips: Vec<IpAddr>,
+    pub ipv4_default_route: bool,
+    pub ipv6_default_route: bool,
 }
 
 impl Default for TproxyArgs {
@@ -25,6 +27,8 @@ impl Default for TproxyArgs {
             tun_name: TUN_NAME.to_string(),
             proxy_addr: PROXY_ADDR,
             bypass_ips: vec![],
+            ipv4_default_route: true,
+            ipv6_default_route: false,
         }
     }
 }
@@ -71,6 +75,16 @@ impl TproxyArgs {
 
     pub fn bypass_ips(mut self, bypass_ips: &[IpAddr]) -> Self {
         self.bypass_ips = bypass_ips.to_vec();
+        self
+    }
+
+    pub fn ipv6_default_route(mut self, enabled: bool) -> Self {
+        self.ipv6_default_route = enabled;
+        self
+    }
+
+    pub fn ipv4_default_route(mut self, enabled: bool) -> Self {
+        self.ipv6_default_route = enabled;
         self
     }
 }


### PR DESCRIPTION
This commit removes an existing IPv6 route if IPv6 is not enabled. This ensures that traffic does not bypass the proxy via IPv6.

Further, this commit does not create the 0.0.0.0/1 and 128.0.0.0/1 routes if there is no default route. In this case, a default route is created. This way, it does not interfere with OpenVPN in a new network namespace without routes.

Major version number increase is due to the behavioral change introduced by removing the route. Are you okay with this, @ssrlive?