### PR TITLE
Add gateway mode support and socket fwmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/
 Cargo.lock
 target/
 .idea/
+.history/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub const TUN_IPV4: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 33));
 pub const TUN_NETMASK: IpAddr = IpAddr::V4(Ipv4Addr::new(255, 255, 255, 0));
 pub const TUN_GATEWAY: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
 pub const TUN_DNS: IpAddr = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+pub const SOCKET_FWMARK_TABLE: &str = "100";
 
 #[allow(dead_code)]
 #[cfg(unix)]
@@ -76,7 +77,7 @@ pub struct TproxyState {
     #[cfg(target_os = "linux")]
     pub(crate) restore_gateway_mode: Option<Vec<String>>,
     #[cfg(target_os = "linux")]
-    pub(crate) restore_port_forwarding: bool,
+    pub(crate) restore_ip_forwarding: bool,
     #[cfg(target_os = "linux")]
     pub(crate) restore_socket_fwmark: Option<Vec<String>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ pub struct TproxyState {
     pub(crate) restore_ipv4_route: Option<Vec<String>>,
     #[cfg(target_os = "linux")]
     pub(crate) restore_ipv6_route: Option<Vec<String>>,
+    #[cfg(target_os = "linux")]
+    pub(crate) restore_gateway_mode: Option<Vec<String>>,
+    #[cfg(target_os = "linux")]
+    pub(crate) restore_port_forwarding: bool,
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub struct TproxyState {
     pub(crate) restore_gateway_mode: Option<Vec<String>>,
     #[cfg(target_os = "linux")]
     pub(crate) restore_port_forwarding: bool,
+    #[cfg(target_os = "linux")]
+    pub(crate) restore_socket_fwmark: Option<Vec<String>>,
 }
 
 #[allow(dead_code)]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -296,7 +296,7 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<TproxyState> {
 
         state.restore_gateway_mode = Some(restore_gateway_mode);
         #[cfg(feature = "log")]
-        log::debug!("restore gateway mode: {}", state.restore_gateway_mode);
+        log::debug!("restore gateway mode: {:?}", state.restore_gateway_mode);
     }
 
     // check for socket fwmark
@@ -340,7 +340,7 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<TproxyState> {
 
         state.restore_socket_fwmark = Some(restore_socket_fwmark);
         #[cfg(feature = "log")]
-        log::debug!("restore socket fwmark: {}", state.restore_socket_fwmark);
+        log::debug!("restore socket fwmark: {:?}", state.restore_socket_fwmark);
     }
 
     // sudo ip link set tun0 up

--- a/src/tproxy_args.rs
+++ b/src/tproxy_args.rs
@@ -14,6 +14,7 @@ pub struct TproxyArgs {
     pub bypass_ips: Vec<IpCidr>,
     pub ipv4_default_route: bool,
     pub ipv6_default_route: bool,
+    pub gateway_mode: bool,
 }
 
 impl Default for TproxyArgs {
@@ -29,6 +30,7 @@ impl Default for TproxyArgs {
             bypass_ips: vec![],
             ipv4_default_route: true,
             ipv6_default_route: false,
+            gateway_mode: false,
         }
     }
 }
@@ -85,6 +87,11 @@ impl TproxyArgs {
 
     pub fn ipv4_default_route(mut self, enabled: bool) -> Self {
         self.ipv6_default_route = enabled;
+        self
+    }
+
+    pub fn gateway_mode(mut self, gateway_mode: bool) -> Self {
+        self.gateway_mode = gateway_mode;
         self
     }
 }

--- a/src/tproxy_args.rs
+++ b/src/tproxy_args.rs
@@ -99,8 +99,8 @@ impl TproxyArgs {
         self
     }
 
-    pub fn socket_fwmark(mut self, socket_fwmark: u32) -> Self {
-        self.socket_fwmark = Some(socket_fwmark);
+    pub fn socket_fwmark(mut self, socket_fwmark: Option<u32>) -> Self {
+        self.socket_fwmark = socket_fwmark;
         self
     }
 

--- a/src/tproxy_args.rs
+++ b/src/tproxy_args.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
-use crate::{IpCidr, PROXY_ADDR, TUN_DNS, TUN_GATEWAY, TUN_IPV4, TUN_MTU, TUN_NAME, TUN_NETMASK};
+use crate::{IpCidr, PROXY_ADDR, SOCKET_FWMARK_TABLE, TUN_DNS, TUN_GATEWAY, TUN_IPV4, TUN_MTU, TUN_NAME, TUN_NETMASK};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct TproxyArgs {
@@ -16,6 +16,7 @@ pub struct TproxyArgs {
     pub ipv6_default_route: bool,
     pub gateway_mode: bool,
     pub socket_fwmark: Option<u32>,
+    pub socket_fwmark_table: String,
 }
 
 impl Default for TproxyArgs {
@@ -33,6 +34,7 @@ impl Default for TproxyArgs {
             ipv6_default_route: false,
             gateway_mode: false,
             socket_fwmark: None,
+            socket_fwmark_table: SOCKET_FWMARK_TABLE.to_string(),
         }
     }
 }
@@ -97,8 +99,13 @@ impl TproxyArgs {
         self
     }
 
-    pub fn socket_fwmark(mut self, socket_fwmark: Option<u32>) -> Self {
-        self.socket_fwmark = socket_fwmark;
+    pub fn socket_fwmark(mut self, socket_fwmark: u32) -> Self {
+        self.socket_fwmark = Some(socket_fwmark);
+        self
+    }
+
+    pub fn socket_fwmark_table(mut self, socket_fwmark_table: &str) -> Self {
+        self.socket_fwmark_table = socket_fwmark_table.to_string();
         self
     }
 }

--- a/src/tproxy_args.rs
+++ b/src/tproxy_args.rs
@@ -15,6 +15,7 @@ pub struct TproxyArgs {
     pub ipv4_default_route: bool,
     pub ipv6_default_route: bool,
     pub gateway_mode: bool,
+    pub socket_fwmark: Option<u32>,
 }
 
 impl Default for TproxyArgs {
@@ -31,6 +32,7 @@ impl Default for TproxyArgs {
             ipv4_default_route: true,
             ipv6_default_route: false,
             gateway_mode: false,
+            socket_fwmark: None,
         }
     }
 }
@@ -92,6 +94,11 @@ impl TproxyArgs {
 
     pub fn gateway_mode(mut self, gateway_mode: bool) -> Self {
         self.gateway_mode = gateway_mode;
+        self
+    }
+
+    pub fn socket_fwmark(mut self, socket_fwmark: Option<u32>) -> Self {
+        self.socket_fwmark = socket_fwmark;
         self
     }
 }


### PR DESCRIPTION
- Updated .gitignore to ignore .history/ directory.
- Added `restore_gateway_mode` and `restore_port_forwarding` fields to `TproxyState` struct.
- Implemented gateway mode setup in `tproxy_setup` function.
- Added logic to restore gateway mode and port forwarding in `_tproxy_remove` function.
- Introduced `gateway_mode` field in `TproxyArgs` struct and its default implementation.
- Added `gateway_mode` method to `TproxyArgs` for setting the gateway mode.