### PR TITLE
restore dns from dhcp in Macos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub(crate) fn get_state_file_path() -> std::path::PathBuf {
 pub struct TproxyState {
     pub(crate) tproxy_args: Option<TproxyArgs>,
     pub(crate) original_dns_servers: Option<Vec<IpAddr>>,
+    #[cfg(target_os = "macos")]
+    pub(crate) dns_servers_if_exist_from_interface: bool,
     pub(crate) gateway: Option<IpAddr>,
     pub(crate) gw_scope: Option<String>,
     pub(crate) umount_resolvconf: bool,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -257,7 +257,8 @@ fn config_dns_servers_empty(original_gw_scope: &str) -> std::io::Result<()> {
     let script = format!(
         r#"
     original_gw_scope={}
-    networksetup -setdnsservers "$original_gw_scope" empty
+    currentservice=$(networksetup -listnetworkserviceorder | grep -B 1 "$original_gw_scope" | head -n 1 | sed 's/.*) //')
+    networksetup -setdnsservers "$currentservice" empty
     "#,
         original_gw_scope
     );
@@ -282,7 +283,8 @@ fn get_dns_servers_if_exist_from_interface(original_gw_scope: &str) -> std::io::
     let script = format!(
         r#"
     original_gw_scope={}
-    dnsservers=$(networksetup -getdnsservers "$original_gw_scope")
+    currentservice=$(networksetup -listnetworkserviceorder | grep -B 1 "$original_gw_scope" | head -n 1 | sed 's/.*) //')
+    dnsservers=$(networksetup -getdnsservers "$currentservice")
     while read line; do
           echo $line | grep 'DNS Servers' > /dev/null 2>&1
           rc="$?"

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -138,8 +138,8 @@ fn _tproxy_remove(state: &mut TproxyState) -> std::io::Result<()> {
                 log::debug!("restore original dns servers error: {}", _err);
             }
         } else if let Err(_err) = config_dns_servers_empty(&original_gw_scope) {
-                log::debug!("restore original dns servers error: {}", _err);
-            }
+            log::debug!("restore original dns servers error: {}", _err);
+        }
     }
 
     let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -137,11 +137,9 @@ fn _tproxy_remove(state: &mut TproxyState) -> std::io::Result<()> {
             if let Err(_err) = configure_dns_servers(&original_dns_servers) {
                 log::debug!("restore original dns servers error: {}", _err);
             }
-        } else {
-            if let Err(_err) = config_dns_servers_empty(&original_gw_scope) {
+        } else if let Err(_err) = config_dns_servers_empty(&original_gw_scope) {
                 log::debug!("restore original dns servers error: {}", _err);
             }
-        }
     }
 
     let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");


### PR DESCRIPTION
Hi,

On my macos,my dns servers are configured by dhcp,  i find that when i restore my dns, tun2proxy will set dns servers fixedly, as a result, when I switch to a different Wi-Fi network, I can no longer access the internet.