### PR TITLE
feat(Linux): phase out reliance on iproute2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ keywords = ["tun", "network", "tunnel", "transparent", "proxy"]
 readme = "readme.md"
 
 [features]
-default = []
 unsafe-state-file = []
+
+# default = ["unsafe-state-file"]
 
 [dependencies]
 cidr = { version = "0.3", features = ["serde"] }
@@ -23,14 +24,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.30", features = ["fs", "mount", "process"] }
+rtnetlink = "0.17"
+tempfile = "3"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 resolv-conf = "0.7"
 system-configuration = "0.6"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.30", features = ["fs", "mount", "process"] }
-tempfile = "3"
-rtnetlink = "0.17"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.60", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tproxy-config"
-version = "6.1.4"
+version = "7.0.0"
 edition = "2024"
 description = "Transparent proxy configuration"
 license = "MIT"
@@ -15,11 +15,13 @@ unsafe-state-file = []
 
 [dependencies]
 cidr = { version = "0.3", features = ["serde"] }
+futures = "0.3.31"
 libloading = "0.8"
 log = { version = "0.4" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 resolv-conf = "0.7"
@@ -28,9 +30,10 @@ system-configuration = "0.6"
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.30", features = ["fs", "mount", "process"] }
 tempfile = "3"
+rtnetlink = "0.17"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.60", features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_SystemServices",
     "Win32_Security_Cryptography",

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,59 @@
+use crate::{TproxyArgs, TproxyState};
+
+#[cfg(target_os = "linux")]
+use crate::linux::{_tproxy_remove, _tproxy_setup};
+
+#[cfg(target_os = "windows")]
+use crate::windows::{_tproxy_remove, _tproxy_setup};
+
+#[cfg(target_os = "macos")]
+use crate::macos::{_tproxy_remove, _tproxy_setup};
+
+impl Drop for TproxyState {
+    fn drop(&mut self) {
+        let inner = self.inner.clone();
+        tokio::spawn(async move {
+            log::debug!("restoring network settings");
+            let mut state = inner.lock().await;
+
+            _ = _tproxy_remove(&mut state).await;
+        });
+    }
+}
+
+pub async fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<TproxyState> {
+    log::debug!("Setting up TProxy with args: {:?}", tproxy_args);
+    match _tproxy_setup(tproxy_args).await {
+        Ok(state) => {
+            log::debug!("TProxy setup completed successfully");
+            Ok(TproxyState::new(state))
+        }
+        Err(e) => {
+            log::error!("Failed to set up TProxy: {}", e);
+            Err(std::io::Error::other(format!("{}", e)))
+        }
+    }
+}
+
+pub async fn tproxy_remove(state: Option<TproxyState>) -> std::io::Result<()> {
+    match state {
+        Some(state) => {
+            let inner = state.inner.clone();
+            let mut state = inner.lock().await;
+            return _tproxy_remove(&mut state)
+                .await
+                .map_err(|e| std::io::Error::other(format!("{}", e)));
+        }
+        #[cfg(all(feature = "unsafe-state-file", any(target_os = "macos", target_os = "windows")))]
+        None => {
+            if let Ok(mut state) = crate::retrieve_intermediate_state() {
+                return _tproxy_remove(&mut state)
+                    .await
+                    .map_err(|e| std::io::Error::other(format!("{}", e)));
+            }
+            Ok(())
+        }
+        #[cfg(not(all(feature = "unsafe-state-file", any(target_os = "macos", target_os = "windows"))))]
+        None => Ok(()),
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -93,7 +93,7 @@ pub(crate) async fn _tproxy_remove(state: &mut TproxyStateInner) -> std::io::Res
     let gateway = tproxy_args.tun_gateway.to_string();
     let args = &["-p", "delete", &unspecified, "mask", &unspecified, &gateway];
     if let Err(_err) = run_command("route", args) {
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
+        log::debug!("command \"route {args:?}\" error: {_err}");
     }
 
     // Remove bypass ips
@@ -101,14 +101,14 @@ pub(crate) async fn _tproxy_remove(state: &mut TproxyStateInner) -> std::io::Res
     for bypass_ip in tproxy_args.bypass_ips.iter() {
         let args = &["delete", &bypass_ip.to_string()];
         if let Err(_err) = run_command("route", args) {
-            log::debug!("command \"route {:?}\" error: {}", args, _err);
+            log::debug!("command \"route {args:?}\" error: {_err}");
         }
     }
     if tproxy_args.bypass_ips.is_empty() && !crate::is_private_ip(tproxy_args.proxy_addr.ip()) {
         let bypass_ip = cidr::IpCidr::new_host(tproxy_args.proxy_addr.ip());
         let args = &["delete", &bypass_ip.to_string()];
         if let Err(_err) = run_command("route", args) {
-            log::debug!("command \"route {:?}\" error: {}", args, _err);
+            log::debug!("command \"route {args:?}\" error: {_err}");
         }
     }
 
@@ -116,7 +116,7 @@ pub(crate) async fn _tproxy_remove(state: &mut TproxyStateInner) -> std::io::Res
     // command: `route delete 0.0.0.0 mask 0.0.0.0`
     let args = &["delete", &unspecified, "mask", &unspecified];
     if let Err(_err) = run_command("route", args) {
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
+        log::debug!("command \"route {args:?}\" error: {_err}");
     }
 
     // 2. Add back the original gateway route
@@ -124,7 +124,7 @@ pub(crate) async fn _tproxy_remove(state: &mut TproxyStateInner) -> std::io::Res
     let original_gateway = original_gateway.to_string();
     let args = &["add", &unspecified, "mask", &unspecified, &original_gateway, "metric", "200"];
     if let Err(_err) = run_command("route", args) {
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
+        log::debug!("command \"route {args:?}\" error: {_err}");
     }
 
     // remove the record file anyway
@@ -190,7 +190,7 @@ pub(crate) fn get_default_gateway_ip() -> std::io::Result<IpAddr> {
     match get_active_network_interface_gateways().map(|gateways| gateways[0]) {
         Ok(gateway) => Ok(gateway),
         Err(e) => {
-            log::debug!("Failed to get default gateway by GetAdaptersAddresses: {}", e);
+            log::debug!("Failed to get default gateway by GetAdaptersAddresses: {e}");
             get_default_gateway_ip_by_cmd()
         }
     }
@@ -201,7 +201,7 @@ pub(crate) fn get_default_gateway_ip_by_cmd() -> std::io::Result<IpAddr> {
     let gateways = match run_command("powershell", &["-Command", cmd]) {
         Ok(gateways) => gateways,
         Err(e) => {
-            let str = format!("Command \"powershell -Command {}\" error: {}", cmd, e);
+            let str = format!("Command \"powershell -Command {cmd}\" error: {e}");
             let err = std::io::Error::other(str);
             return Err(err);
         }
@@ -237,7 +237,7 @@ pub(crate) fn get_default_gateway_interface() -> std::io::Result<String> {
     let iface = match run_command("powershell", &["-Command", cmd]) {
         Ok(iface) => iface,
         Err(e) => {
-            let str = format!("Command \"powershell -Command {}\" error: {}", cmd, e);
+            let str = format!("Command \"powershell -Command {cmd}\" error: {e}");
             let err = std::io::Error::other(str);
             return Err(err);
         }
@@ -364,9 +364,9 @@ mod tests {
     #[test]
     fn test_get_default_gateway() {
         let (addr, iface) = get_default_gateway().unwrap();
-        println!("addr: {:?}, iface: {}", addr, iface);
+        println!("addr: {addr:?}, iface: {iface}");
 
         let gw = get_active_network_interface_gateways().unwrap();
-        println!("gateways: {:?}", gw);
+        println!("gateways: {gw:?}");
     }
 }


### PR DESCRIPTION
This commit removes the dependency on external iproute2 binaries like `ip`. As a result, the `--setup` parameter of tun2proxy can be used inside an OS-less container.

The dependency on `iptables` has not yet been removed. This will remain a todo for a future PR.